### PR TITLE
Fixed Exec String Overflow

### DIFF
--- a/src/components/ProfileCard.js
+++ b/src/components/ProfileCard.js
@@ -9,17 +9,17 @@ export default function ProfileCard(props) {
           className="block h-80 relative rounded shadow leading-snug bg-indigo-50 hover:bg-indigo-100"
           key={props.index}
         >
+          <div className="h-3/4 w-full overflow-hidden">
           <img
             src={props.imageUrl}
             alt={props.imageAlt}
-            className="w-full h-3/4 rounded rounded-b-none object-cover absolute"
+            className="w-full h-full object-cover"
           />
-          <span className="block relative h-full flex justify-start items-end pr-4 pb-4">
-            <div className="flex flex-col items-start">
-              <h3 className="text-lg title px-3">{props.name}</h3>
-              <h4 className="text-sm body px-3">{props.role}</h4>
+          </div>
+          <div className="h-1/4 px-3 py-2 flex flex-col justify-center">
+            <h3 className="text-lg title font-semibold break-words whitespace-normal">{props.name}</h3>
+              <h4 className="text-sm body break-words whitespace-normal">{props.role}</h4>
             </div>
-          </span>
         </span>
       </Link>
     </article>


### PR DESCRIPTION
Fixed overflowing executive names in the exec listings. 
Before: 

<img width="349" alt="Screen Shot 2025-07-03 at 9 35 06 PM" src="https://github.com/user-attachments/assets/2e5c2325-e71a-4a92-a8c0-b639ed5933a4" />

After: 
<img width="349" alt="Screen Shot 2025-07-03 at 9 35 17 PM" src="https://github.com/user-attachments/assets/4d2c37da-2bfd-44e3-a81c-64d47f421f15" />
